### PR TITLE
Refactor authentication and remove redundant roles

### DIFF
--- a/src/main/java/de/aittr/bio_marketplace/controller/ProductController.java
+++ b/src/main/java/de/aittr/bio_marketplace/controller/ProductController.java
@@ -3,12 +3,10 @@ package de.aittr.bio_marketplace.controller;
 import de.aittr.bio_marketplace.controller.responses.ProductResponse;
 import de.aittr.bio_marketplace.controller.responses.ProductsResponse;
 import de.aittr.bio_marketplace.domain.dto.ProductDto;
-import de.aittr.bio_marketplace.domain.entity.Product;
 import de.aittr.bio_marketplace.service.interfaces.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -85,7 +83,7 @@ public class ProductController {
             @RequestParam(value = "sort_order", required = false, defaultValue = "asc")
             @Parameter(description = "Sort order: 'asc' (ascending) or 'desc' (descending)")
             String sortOrder
-            ) {
+    ) {
         BigDecimal minPrice = (minPriceDouble != null) ? BigDecimal.valueOf(minPriceDouble) : null;
         BigDecimal maxPrice = (maxPriceDouble != null) ? BigDecimal.valueOf(maxPriceDouble) : null;
         List<ProductDto> products = service.getAllActiveProductsFiltered(
@@ -127,7 +125,6 @@ public class ProductController {
                     "wrapped in a 'product' object"
     )
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAuthority('ADMIN')")
     public ProductResponse delete(
             @PathVariable
             @Parameter(description = "Product unique identifier")

--- a/src/main/java/de/aittr/bio_marketplace/security/config/SecurityConfig.java
+++ b/src/main/java/de/aittr/bio_marketplace/security/config/SecurityConfig.java
@@ -18,8 +18,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class SecurityConfig {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
-      //настройки CORS
+    //настройки CORS
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
@@ -76,13 +76,14 @@ public class SecurityConfig {
                         // Product Controller   
                         .requestMatchers(HttpMethod.GET, "/products").permitAll()
                         .requestMatchers(HttpMethod.GET, "/products/**").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/products/**").hasRole(ADMIN_ROLE)
 
                         // User Controller
                         .requestMatchers(HttpMethod.GET, "/users").permitAll()
                         .requestMatchers(HttpMethod.PUT, "/users").permitAll()
                         .requestMatchers(HttpMethod.PUT, "/users/**").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/users/**").permitAll()
-                                       
+
                         //разрешаю POST на /orders
                         .requestMatchers(HttpMethod.POST, "/orders").permitAll()
 

--- a/src/main/resources/db/changelog/903-insert-users.xml
+++ b/src/main/resources/db/changelog/903-insert-users.xml
@@ -13,7 +13,6 @@
             <column name="id" valueNumeric="1"/>
             <column name="email" value="seller1@example.com"/>
             <column name="password" value="$2a$10$XURP2fZ0uT1Z/lP.9.5tluF0e2gY0H4gP2gq4Z2X9.5tluF0e2gY0"/>
-            <column name="role_id" valueNumeric="1"/>
             <column name="first_name" value="John"/>
             <column name="last_name" value="Doe"/>
             <column name="avatar" value="https://example.com/avatar.jpg"/>
@@ -25,7 +24,6 @@
             <column name="id" valueNumeric="2"/>
             <column name="email" value="john@gmail.com"/>
             <column name="password" value="$2a$10$3FB6AI7kjByx5Gq.pKDGouKXb.Aa9FObvvUSCl6275PmAEkB2qjh2"/>
-            <column name="role_id" valueNumeric="2"/>
             <column name="first_name" value="Jan"/>
             <column name="last_name" value="Markwiz"/>
             <column name="avatar" value="https://example.com/avatar.jpg"/>


### PR DESCRIPTION
Updated JwtAuthenticationFilter to load user details and roles from the database instead of relying solely on the token. Removed `role_id` column from user inserts and redundant annotations in ProductController, aligning role management with updated logic.